### PR TITLE
Unbinding uniform buffers on context shutdown.

### DIFF
--- a/src/OpenGL/libGLESv2/Context.cpp
+++ b/src/OpenGL/libGLESv2/Context.cpp
@@ -245,6 +245,11 @@ Context::~Context()
 	mState.pixelPackBuffer = nullptr;
 	mState.pixelUnpackBuffer = nullptr;
 	mState.genericUniformBuffer = nullptr;
+
+	for(int i = 0; i < MAX_UNIFORM_BUFFER_BINDINGS; i++) {
+		mState.uniformBuffers[i].set(nullptr, 0, 0);
+	}
+
 	mState.renderbuffer = nullptr;
 
 	for(int i = 0; i < MAX_COMBINED_TEXTURE_IMAGE_UNITS; ++i)


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/swiftshader/issues/detail?id=72