### PR TITLE
Fixed build on gcc 8.2.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,6 +237,13 @@ else()
         "-Werror=sign-compare"
         "-Werror=missing-braces"
     )
+    
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+        list(APPEND SWIFTSHADER_COMPILE_OPTIONS
+            "-Wno-class-memaccess"
+        )
+    endif()
+
 
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         list(APPEND SWIFTSHADER_COMPILE_OPTIONS

--- a/src/Reactor/ReactorUnitTests.cpp
+++ b/src/Reactor/ReactorUnitTests.cpp
@@ -1247,7 +1247,7 @@ using CToReactorCastTestTypes = ::testing::Types
 		std::pair<float,        Float>
 	>;
 
-TYPED_TEST_CASE(CToReactorCastTest, CToReactorCastTestTypes);
+TYPED_TEST_SUITE(CToReactorCastTest, CToReactorCastTestTypes);
 
 TYPED_TEST(CToReactorCastTest, Casts)
 {
@@ -1319,7 +1319,7 @@ using GEPTestTypes = ::testing::Types
 		std::pair<float[4],    Float4>
 	>;
 
-TYPED_TEST_CASE(GEPTest, GEPTestTypes);
+TYPED_TEST_SUITE(GEPTest, GEPTestTypes);
 
 TYPED_TEST(GEPTest, PtrOffsets)
 {

--- a/tests/VulkanUnitTests/unittests.cpp
+++ b/tests/VulkanUnitTests/unittests.cpp
@@ -359,7 +359,7 @@ void SwiftShaderVulkanBufferToBufferComputeTest::test(
     buffers = nullptr;
 }
 
-INSTANTIATE_TEST_CASE_P(ComputeParams, SwiftShaderVulkanBufferToBufferComputeTest, testing::Values(
+INSTANTIATE_TEST_SUITE_P(ComputeParams, SwiftShaderVulkanBufferToBufferComputeTest, testing::Values(
     ComputeParams{512, 1, 1, 1},
     ComputeParams{512, 2, 1, 1},
     ComputeParams{512, 4, 1, 1},


### PR DESCRIPTION
Deprecated macros in Vulkan and Reactor unit tests were updated with current versions.

Warning class-memaccess disabled. It was triggered by PixelProcessor::State memsetting itself in its constructor.

Change-Id: Ifeddbfb5f25817717b55754055b4f0222cea209b