### PR TITLE
Added vkGetPhysicalDeviceWin32PresentationSupportKHR to Vulkan ICD

### DIFF
--- a/src/Vulkan/VkGetProcAddress.cpp
+++ b/src/Vulkan/VkGetProcAddress.cpp
@@ -106,6 +106,7 @@ static const std::unordered_map<std::string, PFN_vkVoidFunction> instanceFunctio
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 	// VK_KHR_win32_surface
 	MAKE_VULKAN_INSTANCE_ENTRY(vkCreateWin32SurfaceKHR),
+	MAKE_VULKAN_INSTANCE_ENTRY(vkGetPhysicalDeviceWin32PresentationSupportKHR),
 #endif
 };
 #undef MAKE_VULKAN_INSTANCE_ENTRY

--- a/src/Vulkan/libVulkan.cpp
+++ b/src/Vulkan/libVulkan.cpp
@@ -2799,6 +2799,13 @@ VKAPI_ATTR VkResult VKAPI_CALL vkCreateWin32SurfaceKHR(VkInstance instance, cons
 
 	return vk::Win32SurfaceKHR::Create(pAllocator, pCreateInfo, pSurface);
 }
+
+VKAPI_ATTR VkBool32 VKAPI_CALL vkGetPhysicalDeviceWin32PresentationSupportKHR(VkPhysicalDevice physicalDevice, uint32_t queueFamilyIndex)
+{
+	TRACE("(VkPhysicalDevice physicalDevice = %p, uint32_t queueFamilyIndex = %d)",
+		physicalDevice, queueFamilyIndex);
+	return VK_TRUE;
+}
 #endif
 
 #ifndef __ANDROID__


### PR DESCRIPTION
This PR adds an ICD entrypoint for ```vkGetPhysicalDeviceWin32PresentationSupportKHR``` to the Win32 platform.

This change will allow tools that make use of this function to work with the swiftshader ICD. One such tool is my Vulkan Hardware Capability viewer, that would crash on ICDs not implementing this.