### PR TITLE
Turn off -Wignored-qualifiers warning for third_party/llvm-16.0

### DIFF
--- a/third_party/llvm-16.0/Android.bp
+++ b/third_party/llvm-16.0/Android.bp
@@ -1496,6 +1496,7 @@ cc_defaults {
     ],
 
     cflags: [
+        "-Wno-ignored-qualifiers",
         "-Wno-implicit-fallthrough",
         "-Wno-unreachable-code-loop-increment",
         "-Wno-unused-parameter",


### PR DESCRIPTION
Turns off new warning found by the latest llvm compiler, which becomes a build error under -Werror.