### PR TITLE
SwiftShader has no PCI bus, so there's nothing to fill in

### DIFF
--- a/src/Vulkan/libVulkan.cpp
+++ b/src/Vulkan/libVulkan.cpp
@@ -3953,6 +3953,9 @@ VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceProperties2(VkPhysicalDevice physi
 				vk::Cast(physicalDevice)->getProperties(properties);
 			}
 			break;
+		case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PCI_BUS_INFO_PROPERTIES_EXT:
+			// SwiftShader is a software renderer with no PCI bus — skip silently.
+			break;
 		default:
 			// "the [driver] must skip over, without processing (other than reading the sType and pNext members) any structures in the chain with sType values not defined by [supported extenions]"
 			UNSUPPORTED("pProperties->pNext sType = %s", vk::Stringify(extensionProperties->sType).c_str());


### PR DESCRIPTION
SwiftShader's vkGetPhysicalDeviceProperties2 aborts in debug builds when encountering VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PCI_BUS_INFO_PROPERTIES_EXT in the pNext chain. This occurs when the Vulkan loader's linux_read_sorted_physical_devices() queries PCI bus info on all physical devices, including SwiftShader. Per the Vulkan spec (section 3.6.2), drivers must skip over unrecognized pNext members without processing them. SwiftShader is a software renderer with no PCI bus, so the correct behavior is to silently skip this sType. Without this fix, loading SwiftShader alongside a hardware GPU driver (e.g., NVIDIA) crashes in debug builds because UNSUPPORTED() calls sw::abort().